### PR TITLE
refractor: Replace deprecated datetime.utcnow()

### DIFF
--- a/pynext/discord/member.py
+++ b/pynext/discord/member.py
@@ -23,7 +23,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Iterable
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from ..utils import str_to_datetime
 
@@ -137,7 +137,7 @@ class GuildMember(DiscordUser):
         if self.communication_disabled_until is None:
             return False
 
-        return self.communication_disabled_until > datetime.utcnow()
+        return self.communication_disabled_until > datetime.now(timezone.utc)
 
     async def fetch_roles(self, user: SelfBot) -> list[Role]:
         """

--- a/pynext/utils.py
+++ b/pynext/utils.py
@@ -113,12 +113,7 @@ def snowflake_time(object_id: int) -> datetime:
 def str_to_datetime(value: str) -> datetime:
     # Method to convert string to datetime object.
     # Example: 2021-08-28T15:00:00.000000+00:00
-
-    tuple_data: tuple[str, ...] = value.partition("T")
-    datetime_str: str = f"{tuple_data[0]} {tuple_data[2][0:8]}"
-
-    datetime_object: datetime = datetime.strptime(datetime_str, "%Y-%m-%d %H:%M:%S")
-    return datetime_object
+    return datetime.fromisoformat(value)
 
 
 def applications_filter(data: dict[str, Any]) -> dict[int, Any]:


### PR DESCRIPTION
## Summary

### What is this pull request for?
Changes deprecated `datetime.utcnow()` to `datetime.now(timezone.utc)` in **is_muted** method.

### This is a **Code Change**

- [x] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
