### PR TITLE
refractor: Make httpclient public in PynextClient

### DIFF
--- a/pynext/client.py
+++ b/pynext/client.py
@@ -125,8 +125,8 @@ class PynextClient:
             HTTP Session is not defined.
         """
         for token in set(auths):
-            if data := await self._http.login_request(token):
-                user: SelfBot = SelfBot(token=token, user_data=data, http=self._http)
+            if data := await self.http.login_request(token):
+                user: SelfBot = SelfBot(token=token, user_data=data, http=self.http)
 
                 self._users.add(user)
                 self._logger.info(f"Connected to the account: {user}.")
@@ -146,7 +146,7 @@ class PynextClient:
         """
         self._logger.info(f"Running client, {len(set(tokens))} tokens loaded.")
 
-        await self._http.setup()
+        await self.http.setup()
         await self.login(*tokens)
         await self.gateway.start()
 

--- a/pynext/client.py
+++ b/pynext/client.py
@@ -70,6 +70,8 @@ class PynextClient:
         Major client dispatcher.
     http: :class:`HTTPClient`
         HTTP client used to send requests to rest api.
+
+        .. versionadded:: 1.2.0
     """
 
     __version__: ClassVar[str] = "1.1.0"

--- a/pynext/client.py
+++ b/pynext/client.py
@@ -68,10 +68,12 @@ class PynextClient:
         Client event loop.
     dispatcher: :class:`Dispatcher`
         Major client dispatcher.
+    http: :class:`HTTPClient`
+        HTTP client used to send requests to rest api.
     """
 
     __version__: ClassVar[str] = "1.1.0"
-    __slots__ = ("gateway", "loop", "dispatcher", "_http", "_users", "_logger")
+    __slots__ = ("gateway", "loop", "dispatcher", "http", "_users", "_logger")
 
     def __init__(
         self,
@@ -88,12 +90,13 @@ class PynextClient:
             chunk_channels=chunk_channels,
             debug_events=debug_events,
         )
+
         self.loop: AbstractEventLoop = get_event_loop()
         self.dispatcher: Dispatcher[PynextClient] = Dispatcher(client=self)
-
-        self._http: HTTPClient = HTTPClient(
+        self.http: HTTPClient = HTTPClient(
             request_delay, ratelimit_delay, self.dispatcher, http_timeout
         )
+
         self._logger: Logger = getLogger("pynext.common")
         self._users: set[SelfBot] = set()
 


### PR DESCRIPTION
## Summary

### What is this pull request for?
After more thought, I decided to change the `http` attribute in the `PynextClient` class to a public attribute.

### This is a **Code Change**

- [x] I have tested my changes.
- [ ] I have updated the documentation to reflect the changes.
