### PR TITLE
refractor: Deprecate .event decorator

### DIFF
--- a/docs/examples/events.rst
+++ b/docs/examples/events.rst
@@ -10,12 +10,12 @@ Events Example
 
    client = PynextClient()
 
-   @client.gateway.event('on_user_ready')
+   @client.dispatcher.listen('on_user_ready')
    async def on_ready(user: SelfBot):
       print(f"Selfbot: {user.username} is ready!")
 
 
-   @client.gateway.event('on_message_create')
+   @client.dispatcher.listen('on_message_create')
    async def on_message(user: SelfBot, message: Union[GuildMessage, PrivateMessage]):
        print(f"{user.username} received an event on_message!")
        print(message.content)

--- a/docs/examples/sending_files.rst
+++ b/docs/examples/sending_files.rst
@@ -17,7 +17,7 @@ Sending Files Example
    """
 
 
-   @client.gateway.event("on_user_ready")
+   @client.dispatcher.listen("on_user_ready")
    async def on_ready(user: SelfBot):
       print(f"Selfbot: {user.username} is ready!")
 

--- a/docs/examples/slashcommands.rst
+++ b/docs/examples/slashcommands.rst
@@ -11,7 +11,7 @@ SlashCommands Example
    client = PynextClient(chunk_guilds=False)
 
 
-   @client.gateway.event("on_user_ready")
+   @client.dispatcher.listen("on_user_ready")
    async def on_ready(user: SelfBot):
       print(f"Selfbot: {user.username} is ready!")
 

--- a/examples/events.py
+++ b/examples/events.py
@@ -10,12 +10,12 @@ The first one:
 client = PynextClient()
 
 
-@client.gateway.event("on_user_ready")
+@client.dispatcher.listen("on_user_ready")
 async def on_ready(user: SelfBot):
     print(f"Selfbot: {user.username} is ready!")
 
 
-@client.gateway.event("on_message_create")
+@client.dispatcher.listen("on_message_create")
 async def on_message(user: SelfBot, message: Union[GuildMessage, PrivateMessage]):
     print(f"{user.username} received an event on_message!")
     print(message.content)

--- a/examples/sending_files.py
+++ b/examples/sending_files.py
@@ -10,7 +10,7 @@ To avoid this, you can increase the timeout limit.
 """
 
 
-@client.gateway.event("on_user_ready")
+@client.dispatcher.listen("on_user_ready")
 async def on_ready(user: SelfBot):
     print(f"Selfbot: {user.username} is ready!")
 

--- a/examples/slash_commands.py
+++ b/examples/slash_commands.py
@@ -4,7 +4,7 @@ from pynext import PynextClient, SelfBot, Guild, Application, SlashCommand
 client = PynextClient(chunk_guilds=False)
 
 
-@client.gateway.event("on_user_ready")
+@client.dispatcher.listen("on_user_ready")
 async def on_ready(user: SelfBot):
     print(f"Selfbot: {user.username} is ready!")
 

--- a/pynext/gateway/response.py
+++ b/pynext/gateway/response.py
@@ -92,4 +92,4 @@ class GatewayResponse:
             return None
 
         converter: dict[str, str] = {event.name: event.value for event in Events}
-        return converter.get(event_name, event_name)
+        return converter.get(event_name)

--- a/pynext/gateway/websocket.py
+++ b/pynext/gateway/websocket.py
@@ -143,10 +143,7 @@ class WebSocketConnector:
         )
 
         for user in self.client.users:
-            websocket: DiscordWebSocket = DiscordWebSocket(
-                user=user,
-                connector=self
-            )
+            websocket: DiscordWebSocket = DiscordWebSocket(user=user, connector=self)
             task: Task = self.client.loop.create_task(websocket.run(self.gateway_url))
             tasks.append(task)
 
@@ -166,7 +163,7 @@ class WebSocketConnector:
         warn(
             "Using client.gateway.event is deprecated. Use client.dispatcher.listen instead.",
             DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
         return self.client.dispatcher.listen(event_name)
 
@@ -216,7 +213,6 @@ class DiscordWebSocket:
         user: SelfBot,
         connector: WebSocketConnector,
     ) -> None:
-
         self.user: SelfBot = user
         self.websocket: ClientWebSocketResponse | None = None
         self.connected: Event = Event()

--- a/pynext/gateway/websocket.py
+++ b/pynext/gateway/websocket.py
@@ -25,8 +25,10 @@ from typing import TYPE_CHECKING, Any, ClassVar, Callable
 
 from logging import Logger, getLogger
 from aiohttp import ClientWebSocketResponse
+
 from asyncio import gather, Queue, Task, sleep, create_task, Event
 from time import time, perf_counter
+from warnings import warn
 
 from ..utils import json_dumps
 from ..enums import GatewayCodes
@@ -60,15 +62,21 @@ class WebSocketConnector:
     ----------
     client: :class:`PynextClient`
         Pynext client.
+    chunk_guilds: :class:`bool`
+        Whether the client should chunk guilds of each selfbot.
+    chunk_channels: :class:`bool`
+        Whether the client should chunks guild channels.
+    debug_events: :class:`bool`
+        Whether the client should run debug events such as: on_websocket_raw_receive.
     """
 
     __slots__ = (
         "client",
-        "_events",
+        "chunk_guilds",
+        "chunk_channels",
+        "debug_events",
         "_logger",
-        "_chunk_guilds",
-        "_chunk_channels",
-        "_debug_events",
+        "_websockets",
     )
 
     gateway_url: ClassVar[str] = "wss://gateway.discord.gg/?v=10&encoding=json"
@@ -81,12 +89,43 @@ class WebSocketConnector:
         debug_events: bool,
     ):
         self.client: PynextClient = client
+        self.chunk_guilds: bool = chunk_guilds
+        self.chunk_channels: bool = chunk_channels
+        self.debug_events: bool = debug_events
 
-        self._chunk_guilds: bool = chunk_guilds
-        self._chunk_channels: bool = chunk_channels
-        self._debug_events: bool = debug_events
-
+        self._websockets: dict[SelfBot, DiscordWebSocket] = {}
         self._logger: Logger = getLogger("pynext.gateway")
+
+    @property
+    def websockets(self) -> dict[SelfBot, DiscordWebSocket]:
+        """
+        A dictionary with websocket connections.
+        """
+        return self._websockets
+
+    def get_websocket(self, user: SelfBot) -> DiscordWebSocket | None:
+        """
+        Method to get websocket connection for user.
+        """
+        return self._websockets.get(user)
+
+    def add_websocket(self, websocket: DiscordWebSocket) -> None:
+        """
+        Method to add websocket to the connector.
+        """
+        websocket.connected.set()
+        websocket.user.gateway = websocket
+        self._websockets[websocket.user] = websocket
+
+    def remove_websocket(self, websocket: DiscordWebSocket) -> None:
+        """
+        Method to remove websocket from the connector.
+        """
+        try:
+            del self._websockets[websocket.user]
+            websocket.connected.clear()
+        except KeyError:
+            pass
 
     async def start(self, reconnect: bool = False):
         """
@@ -104,15 +143,11 @@ class WebSocketConnector:
         )
 
         for user in self.client.users:
-            web_socket = DiscordWebSocket(
+            websocket: DiscordWebSocket = DiscordWebSocket(
                 user=user,
-                client=self.client,
-                chunk_guilds=self._chunk_guilds,
-                chunk_channels=self._chunk_channels,
-                debug_events=self._debug_events,
+                connector=self
             )
-
-            task: Task = self.client.loop.create_task(web_socket.run(self.gateway_url))
+            task: Task = self.client.loop.create_task(websocket.run(self.gateway_url))
             tasks.append(task)
 
         await gather(*tasks)
@@ -125,7 +160,14 @@ class WebSocketConnector:
         ----------
         event_name:
             Event name to register.
+
+        # TODO: Remove this method in the future and change 'gateway' attribute to 'connector' in Selfbot.
         """
+        warn(
+            "Using client.gateway.event is deprecated. Use client.dispatcher.listen instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         return self.client.dispatcher.listen(event_name)
 
 
@@ -137,14 +179,6 @@ class DiscordWebSocket:
     ----------
     user:
         Selfbot assigned to the connection.
-    client:
-        Pynext client.
-    chunk_guilds:
-        Whether the client should chunk selfbot guilds.
-    chunk_channels:
-        Whether the client should chunks guild channels.
-    debug_events:
-        Whether the client should run debug events such as: ``on_websocket_raw_receive``.
 
     Attributes
     ----------
@@ -166,6 +200,7 @@ class DiscordWebSocket:
         "dispatcher",
         "connected",
         "latency",
+        "connector",
         "_request_queue",
         "_last_send",
         "_client",
@@ -179,23 +214,23 @@ class DiscordWebSocket:
     def __init__(
         self,
         user: SelfBot,
-        client: PynextClient,
-        chunk_guilds: bool,
-        chunk_channels: bool,
-        debug_events: bool,
+        connector: WebSocketConnector,
     ) -> None:
+
         self.user: SelfBot = user
         self.websocket: ClientWebSocketResponse | None = None
         self.connected: Event = Event()
-        self.dispatcher: Dispatcher[PynextClient] = client.dispatcher
+
+        self.connector: WebSocketConnector = connector
+        self.dispatcher: Dispatcher[PynextClient] = connector.client.dispatcher
         self.latency: float = 0.0
 
         self._parser: Parser = Parser(
-            chunk_guilds=chunk_guilds, chunk_channels=chunk_channels
+            chunk_guilds=connector.chunk_guilds, chunk_channels=connector.chunk_channels
         )
         self._request_queue: Queue[dict[str, Any]] = Queue()
-        self._client: PynextClient = client
-        self._debug_events: bool = debug_events
+        self._client: PynextClient = connector.client
+        self._debug_events: bool = connector.debug_events
 
         self._logger: Logger = getLogger("pynext.gateway")
         self._pulse: int = 10
@@ -229,7 +264,7 @@ class DiscordWebSocket:
 
             self._logger.info("Closing gateway connection...")
 
-            self.connected.clear()
+            self.connector.remove_websocket(self)
             await self.websocket.close()
 
     async def run(self, gateway_url: str) -> None:
@@ -242,8 +277,7 @@ class DiscordWebSocket:
             Url to connect gateway.
         """
         self.websocket = await self.user.http.connect_to_gateway(url=gateway_url)
-        self.connected.set()
-        self.user.gateway = self
+        self.connector.add_websocket(self)
 
         self._logger.info(f"Connected {self.user} to the discord gateway.")
 

--- a/pynext/rest/httpclient.py
+++ b/pynext/rest/httpclient.py
@@ -468,8 +468,6 @@ class HTTPClient:
         if message_reference:
             payload["allowed_mentions"] = {"replied_user": reply_mention}
 
-        print(payload)
-
         response: ClientResponse = await self.request(route, payload, user)
         return await response.json()
 


### PR DESCRIPTION
## Summary

### What is this pull request for?
Makes the `.event` decorator deprecated. And it also makes WebSocketConnector more useful.

### This is a **Code Change**

- [x] I have tested my changes.
- [x] I have updated the documentation to reflect the changes.
